### PR TITLE
feat(notifications): expose methods to get a notification content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`matrix-ui-serializable` is a Rust library that wraps `matrix-sdk` / `matrix-sdk-ui` in a still-higher-level, **frontend-agnostic** abstraction. It exposes serializable structs (`RoomsList`, `RoomScreen`, profiles, etc.) representing reactive UI state. It is not an app — it is consumed by an "adapter" (e.g. [tauri-plugin-matrix-svelte](https://github.com/IT-ess/tauri-plugin-matrix-svelte)) that bridges the serialized state to a concrete frontend. The design follows MVVM: this lib + adapter are Model/ViewModel, the frontend is the View.
+
+Much of the logic is a port/adaptation of [Robrix](https://github.com/project-robius/robrix).
+
+## Commands
+
+```bash
+cargo build                 # build the library
+cargo clippy --all-targets  # lint (treat warnings as the bar to clear)
+cargo fmt                   # format
+cargo doc --open            # the public API is the contract for adapters; docs matter
+```
+
+There is currently **no test suite** (no `#[test]`/`#[tokio::test]` in `src/`). `cargo mutants` artifacts are gitignored, suggesting mutation testing has been used ad hoc. Verification is mostly through downstream adapters/examples.
+
+## Module visibility convention
+
+Only `commands` and `models` are `pub`. Everything else (`account`, `events`, `init`, `room`, `stores`, `user`, `utils`) is `pub(crate)`. **The public API surface that adapters depend on lives in `src/commands.rs`, `src/models/`, and `src/lib.rs`** — changing signatures there is a breaking change for adapters. Internal modules can be refactored freely.
+
+## The three communication channels (adapter <-> lib)
+
+Everything an adapter does flows through one of these three mechanisms; understanding them is the key to the codebase:
+
+1. **State updates (lib -> frontend).** The adapter implements the `StateUpdater` trait (`src/models/state_updater.rs`) and passes it in `LibConfig`. Its `update_*` methods (`update_rooms_list`, `update_room`, `update_login_state`, `persist_login_session`, ...) receive the backend Rust structs (which all derive `Serialize`) and are responsible for translating/serializing them into the frontend's state. The lib calls these whenever state changes.
+
+2. **Commands (frontend -> lib, with a response).** Free functions in `src/commands.rs` the adapter exposes to its frontend (login, media upload, profile edits, room creation, fetching previews, etc.).
+
+3. **Events.**
+   - *Outgoing* (`EmitEvent` in `src/models/events.rs`): broadcast via a tokio `broadcast` channel. `init()` returns the `Receiver`; the adapter forwards events to the frontend.
+   - *Incoming* (`EventReceivers` in `src/lib.rs`): tokio `mpsc` receivers the adapter feeds (verification responses, active-room changes, login payloads, OAuth deeplinks).
+
+## Initialization & runtime model
+
+`init(LibConfig)` (`src/lib.rs`) is the single entry point; it returns `broadcast::Receiver<EmitEvent>`. `LibConfig::new` takes the `StateUpdater`, `EventReceivers`, an optional serialized session (restore vs. fresh login), the app data dir (`PathBuf` for the Matrix sqlite DB), and OAuth client/redirect URIs.
+
+The runtime is built on **global singletons** (`src/init/singletons.rs`) initialized once during `init` — notably `CLIENT`, `CURRENT_USER_ID`, `SYNC_SERVICE`, `REQUEST_SENDER`, `EVENT_BRIDGE`, `APP_DATA_DIR`, and a `GLOBAL_BROADCASTER` for `UIUpdateMessage::RefreshUI`. Because state is global, this lib is effectively a single-client singleton per process.
+
+Login supports two flows decided by `check_homeserver_auth_type`: native Matrix password auth and OAuth (`src/init/oauth.rs`, `login.rs`). A `TEMP_CLIENT` is held during login because the user can change homeserver before authenticating. Token refresh persistence is wired via `setup_token_background_save` + `persist_refreshed_session`.
+
+## Two-tier async worker / queue pattern (important)
+
+Work is decoupled from UI rendering through two layers — when adding a feature, follow this pattern rather than calling the SDK directly from a command:
+
+- **`MatrixRequest` async worker** (`src/models/async_requests.rs` + `async_worker` in `src/init/workers.rs`). UI/command code calls `submit_async_request(MatrixRequest::...)`, which sends over `REQUEST_SENDER` to a single async worker. The worker matches the request and usually spawns a task that talks to the SDK (paginate, edit, react, redact, join/leave, fetch profiles/members/previews, send messages, etc.). To add an operation: add a variant to `MatrixRequest`, handle it in `async_worker`, and call `submit_async_request`.
+
+- **`SegQueue` enqueue/process pattern.** Several subsystems use a global `crossbeam_queue::SegQueue` with an `enqueue_*` producer and a `process_*` consumer drained on UI refresh: `rooms_list` (`RoomsListUpdate`), `preview` (`RoomPreviewUpdate`), `notifications` (toast), `user/user_profile` (`UserProfileUpdate`). Producers can run from any task; the consumer runs in `ui_worker`.
+
+The **`ui_worker`** (`src/init/workers.rs`) owns the single `RoomsList` (behind a `Mutex`), listens for active-room changes, and on each debounced `RefreshUI` broadcast (debounced ~200ms via `debounce_broadcast`) drains the queues and pushes state to the adapter through the `StateUpdater`. `async_main_loop` starts the sync (`src/init/sync.rs`) and the `ui_worker`.
+
+## Timelines
+
+`TimelineKind` (`src/events/timeline.rs`) distinguishes `MainRoom { room_id }` from `Thread { room_id, thread_root_event_id }` and is the key for most per-timeline state and requests. Each open timeline has its own unbounded `crossbeam_channel` of `TimelineUpdate`s, created when a room is joined or a thread is opened. `RoomScreen` (`src/room/room_screen.rs`) holds a timeline's UI state and `process_timeline_updates()` applies pending updates. Frontend-facing event DTOs live under `src/room/frontend_events/` (msg-like events, state events, virtual events, thread summaries, timeline item IDs).
+
+## Other notable areas
+
+- `src/account/` — device verification, recovery, key backup.
+- `src/room/` — `rooms_list`, `joined_room`/`invited_room`, `room_screen`, `preview`, `room_filter`, `tags`, `notifications` (incl. push via Sygnal).
+- `src/models/matrix_uri.rs` + `events/event_preview.rs` — matrix.to URI / pill resolution and message previews.
+- `#![recursion_limit = "256"]` is set in `lib.rs` (needed for the SDK's generated types).
+- Edition 2024; `matrix-sdk` is pinned to `0.18.0` with `default-features = false` — SDK minor bumps are routinely breaking, so expect to adapt call sites when bumping (see recent commits).
+
+## Errors
+
+The crate's `Error` (`src/lib.rs`) wraps `io`, `anyhow`, and `matrix_sdk::Error`, and implements `Serialize` (as its `Display` string) so command errors can cross to the frontend. Public commands return `crate::Result<T>`; internal code freely uses `anyhow`.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -59,7 +59,7 @@ use tokio::{sync::oneshot, time::sleep};
 /// Try to build the client from the url given by the frontend and set its singleton.
 /// Once called, the client is set and the init process can proceed (by calling check_homeserver_auth_type)
 pub async fn build_temp_client_from_homeserver_url(homeserver: String) -> crate::Result<()> {
-    let (client, client_session) = build_client(Some(homeserver), None).await?;
+    let (client, client_session) = build_client(Some(homeserver), None, None).await?;
     {
         let mut temp_session = TEMP_CLIENT_SESSION.lock().unwrap();
         *temp_session = Some(client_session);
@@ -466,4 +466,138 @@ pub async fn register_notifications(
     crate::room::notifications::register_os_desktop_notifications(client).await;
 
     Ok(())
+}
+
+/// Resolve and decrypt a single push notification from a background process.
+///
+/// This is meant to be called from a native, UI-less entry point (e.g. an iOS
+/// Notification Service Extension or an Android background service) when a
+/// silent push containing only a `room_id` and `event_id` is received, possibly
+/// while the main app is killed. It is fully self-contained: it does **not**
+/// rely on [`crate::init`], the global singletons, the sync service, the
+/// `StateUpdater` or the event bridge.
+///
+/// It restores a lightweight client from the stored session (using a distinct
+/// cross-process store lock holder so it can run alongside a live main app),
+/// then uses [`matrix_sdk_ui::notification_client::NotificationClient`] to fetch
+/// and decrypt the event, returning display-ready content for the caller to turn
+/// into an OS notification.
+///
+/// * `session` — the serialized `FullMatrixSession` stored by the adapter (the
+///   same string passed to `LibConfig`).
+/// * `app_data_dir` — the application data directory (same as `LibConfig`).
+///
+/// If the access/refresh tokens were rotated while resolving the notification,
+/// the returned [`FrontendNotificationResult::refreshed_session`] holds an
+/// updated serialized session that the caller must persist.
+#[cfg(any(target_os = "android", target_os = "ios"))]
+pub async fn get_notification_item(
+    session: String,
+    app_data_dir: std::path::PathBuf,
+    room_id: OwnedRoomId,
+    event_id: OwnedEventId,
+) -> crate::Result<crate::models::notification::FrontendNotificationResult> {
+    use crate::{
+        init::session::FullMatrixSession,
+        init::singletons::APP_DATA_DIR,
+        models::notification::{
+            FrontendNotificationItem, FrontendNotificationResult, FrontendNotificationStatus,
+        },
+        room::notifications::{event_notification_body, truncate},
+    };
+    use matrix_sdk_ui::notification_client::{
+        NotificationClient, NotificationEvent, NotificationProcessSetup, NotificationStatus,
+    };
+
+    // The background process is fresh, so APP_DATA_DIR is unset; `build_client`
+    // waits on it. Ignore the error in case it was already set.
+    let _ = APP_DATA_DIR.set(app_data_dir);
+
+    let FullMatrixSession {
+        client_session,
+        user_session,
+    } = serde_json::from_str(&session).map_err(anyhow::Error::from)?;
+
+    // Build a client sharing the same on-disk store as the main app, but with a
+    // distinct cross-process lock holder name. Do not set the CLIENT singleton
+    // or start any sync/worker: this client is local to this call.
+    let (client, client_session) =
+        build_client(None, Some(client_session), Some("notifications")).await?;
+    client.restore_session(user_session).await?;
+
+    // Watch for token rotation during the notification fetch so we can hand the
+    // refreshed session back to the caller for persistence.
+    let mut session_changes = client.subscribe_to_session_changes();
+
+    let notification_client =
+        NotificationClient::new(client.clone(), NotificationProcessSetup::MultipleProcesses)
+            .await
+            .map_err(anyhow::Error::from)?;
+
+    let status = notification_client
+        .get_notification(&room_id, &event_id)
+        .await
+        .map_err(anyhow::Error::from)?;
+
+    let status = match status {
+        NotificationStatus::Event(item) => {
+            let item = *item;
+            let sender_name = item
+                .sender_display_name
+                .clone()
+                .unwrap_or_else(|| item.event.sender().localpart().to_owned());
+
+            let body = match &item.event {
+                NotificationEvent::Timeline(event) => {
+                    event_notification_body(event, &sender_name).map(truncate)
+                }
+                NotificationEvent::Invite(_) => Some(format!("{sender_name} invited you to chat.")),
+            };
+
+            let summary = if item.is_direct_message_room {
+                sender_name
+            } else {
+                format!("{sender_name} in {}", item.room_computed_display_name)
+            };
+
+            FrontendNotificationStatus::Event(FrontendNotificationItem {
+                summary,
+                body,
+                sender_display_name: item.sender_display_name,
+                sender_avatar_url: item.sender_avatar_url,
+                room_display_name: item.room_computed_display_name,
+                room_avatar_url: item.room_avatar_url,
+                is_dm: item.is_direct_message_room,
+                is_noisy: item.is_noisy,
+                has_mention: item.has_mention,
+                thread_id: item.thread_id,
+            })
+        }
+        NotificationStatus::EventNotFound => FrontendNotificationStatus::NotFound,
+        NotificationStatus::EventFilteredOut => FrontendNotificationStatus::FilteredOut,
+        NotificationStatus::EventRedacted => FrontendNotificationStatus::Redacted,
+    };
+
+    // Drain any session change that happened during the fetch.
+    let mut tokens_refreshed = false;
+    while let Ok(change) = session_changes.try_recv() {
+        if matches!(change, matrix_sdk::SessionChange::TokensRefreshed) {
+            tokens_refreshed = true;
+        }
+    }
+
+    let refreshed_session = if tokens_refreshed {
+        client
+            .session()
+            .map(|auth| serde_json::to_string(&FullMatrixSession::new(client_session, auth)))
+            .transpose()
+            .map_err(anyhow::Error::from)?
+    } else {
+        None
+    };
+
+    Ok(FrontendNotificationResult {
+        status,
+        refreshed_session,
+    })
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -47,10 +47,11 @@ pub use matrix_sdk::ruma::{
 use matrix_sdk::{
     attachment::{AttachmentInfo, Thumbnail},
     encryption::CrossSigningResetAuthType,
+    media::MediaRequestParameters,
     ruma::{
         DeviceId, OwnedMxcUri, OwnedRoomOrAliasId,
         api::client::uiaa::{self, MatrixUserIdentifier, UserIdentifier},
-        events::room::message::TextMessageEventContent,
+        events::room::{MediaSource, message::TextMessageEventContent},
     },
 };
 
@@ -490,7 +491,7 @@ pub async fn register_notifications(
 /// If the access/refresh tokens were rotated while resolving the notification,
 /// the returned [`FrontendNotificationResult::refreshed_session`] holds an
 /// updated serialized session that the caller must persist.
-#[cfg(any(target_os = "android", target_os = "ios"))]
+// #[cfg(any(target_os = "android", target_os = "ios"))]
 pub async fn get_notification_item(
     session: String,
     app_data_dir: std::path::PathBuf,
@@ -560,11 +561,27 @@ pub async fn get_notification_item(
                 format!("{sender_name} in {}", item.room_computed_display_name)
             };
 
+            let sender_avatar = if let Some(mxc_uri) = item.sender_avatar_url {
+                client
+                    .media()
+                    .get_media_content(
+                        &MediaRequestParameters {
+                            source: MediaSource::Plain(OwnedMxcUri::from(mxc_uri)),
+                            format: matrix_sdk::media::MediaFormat::File,
+                        },
+                        true,
+                    )
+                    .await
+                    .ok() // We ignore the error
+            } else {
+                None
+            };
+
             FrontendNotificationStatus::Event(FrontendNotificationItem {
                 summary,
                 body,
                 sender_display_name: item.sender_display_name,
-                sender_avatar_url: item.sender_avatar_url,
+                sender_avatar,
                 room_display_name: item.room_computed_display_name,
                 room_avatar_url: item.room_avatar_url,
                 is_dm: item.is_direct_message_room,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -60,7 +60,12 @@ use tokio::{sync::oneshot, time::sleep};
 /// Try to build the client from the url given by the frontend and set its singleton.
 /// Once called, the client is set and the init process can proceed (by calling check_homeserver_auth_type)
 pub async fn build_temp_client_from_homeserver_url(homeserver: String) -> crate::Result<()> {
-    let (client, client_session) = build_client(Some(homeserver), None, None).await?;
+    let (client, client_session) = build_client(
+        Some(homeserver),
+        None,
+        crate::init::login::main_client_lock_config(),
+    )
+    .await?;
     {
         let mut temp_session = TEMP_CLIENT_SESSION.lock().unwrap();
         *temp_session = Some(client_session);
@@ -469,24 +474,34 @@ pub async fn register_notifications(
     Ok(())
 }
 
-/// Resolve and decrypt a single push notification from a background process.
+/// How the process resolving a push notification relates to the app's process.
 ///
-/// This is meant to be called from a native, UI-less entry point (e.g. an iOS
-/// Notification Service Extension or an Android background service) when a
-/// silent push containing only a `room_id` and `event_id` is received, possibly
-/// while the main app is killed. It is fully self-contained: it does **not**
-/// rely on [`crate::init`], the global singletons, the sync service, the
-/// `StateUpdater` or the event bridge.
-///
-/// It restores a lightweight client from the stored session (using a distinct
-/// cross-process store lock holder so it can run alongside a live main app),
-/// then uses [`matrix_sdk_ui::notification_client::NotificationClient`] to fetch
-/// and decrypt the event, returning display-ready content for the caller to turn
-/// into an OS notification.
+/// Mirrors [`matrix_sdk_ui::notification_client::NotificationProcessSetup`]
+/// without carrying SDK types: this crate resolves the sync-service handle and
+/// the cross-process lock configuration internally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotificationProcessMode {
+    /// The push handler runs inside the app's own process — Android, where FCM
+    /// wakes the (possibly killed) app process itself. The notification client
+    /// is derived from the app's live client when there is one, sharing its
+    /// auth context so token refreshes can't race the app, and is cached
+    /// across pushes.
+    SingleProcess,
+    /// The push handler runs in a dedicated short-lived process — the iOS
+    /// Notification Service Extension. A standalone client with a distinct
+    /// cross-process store-lock holder is built on each call.
+    MultipleProcesses,
+}
+
+/// Resolve and decrypt a single push notification from a background entry
+/// point (the iOS Notification Service Extension, or the Android FCM service —
+/// warm or cold) when a silent push containing only a `room_id` and `event_id`
+/// is received, possibly while the main app is killed.
 ///
 /// * `session` — the serialized `FullMatrixSession` stored by the adapter (the
 ///   same string passed to `LibConfig`).
 /// * `app_data_dir` — the application data directory (same as `LibConfig`).
+/// * `mode` — see [`NotificationProcessMode`]; pick by platform.
 ///
 /// If the access/refresh tokens were rotated while resolving the notification,
 /// the returned [`FrontendNotificationResult::refreshed_session`] holds an
@@ -497,33 +512,196 @@ pub async fn get_notification_item(
     app_data_dir: std::path::PathBuf,
     room_id: OwnedRoomId,
     event_id: OwnedEventId,
+    mode: NotificationProcessMode,
 ) -> crate::Result<crate::models::notification::FrontendNotificationResult> {
-    use crate::{
-        init::session::FullMatrixSession,
-        init::singletons::APP_DATA_DIR,
-        models::notification::{
-            FrontendNotificationItem, FrontendNotificationResult, FrontendNotificationStatus,
-        },
-        room::notifications::{event_notification_body, truncate},
-    };
-    use matrix_sdk_ui::notification_client::{
-        NotificationClient, NotificationEvent, NotificationProcessSetup, NotificationStatus,
-    };
+    use crate::init::singletons::{APP_DATA_DIR, RUNTIME_HANDLE};
 
-    // The background process is fresh, so APP_DATA_DIR is unset; `build_client`
-    // waits on it. Ignore the error in case it was already set.
+    // A push-only (cold) process is fresh, so APP_DATA_DIR is unset;
+    // `build_client` waits on it. Ignore the error in case it was already set.
     let _ = APP_DATA_DIR.set(app_data_dir);
+
+    match mode {
+        NotificationProcessMode::MultipleProcesses => {
+            get_notification_item_multi_process(session, room_id, event_id).await
+        }
+        NotificationProcessMode::SingleProcess => {
+            // When the app runtime is up (warm push), run the fetch on it: the
+            // caller may be on a short-lived runtime (the Android JNI entry),
+            // and tasks the SDK spawns mid-call must outlive that caller.
+            if let Some(handle) = RUNTIME_HANDLE.get() {
+                handle
+                    .spawn(get_notification_item_single_process(
+                        session, room_id, event_id,
+                    ))
+                    .await
+                    .map_err(anyhow::Error::from)?
+            } else {
+                get_notification_item_single_process(session, room_id, event_id).await
+            }
+        }
+    }
+}
+
+/// Single-process (Android) notification resolution: one client per process.
+///
+/// Reuses the process-wide cached notification client, building it on first
+/// use — derived from the app's live client when the app is running, or as a
+/// standalone client restored from `session` in a push-only (cold) process. A
+/// standalone entry is swapped out for an app-derived one as soon as the app
+/// has started.
+async fn get_notification_item_single_process(
+    session: String,
+    room_id: OwnedRoomId,
+    event_id: OwnedEventId,
+) -> crate::Result<crate::models::notification::FrontendNotificationResult> {
+    use crate::init::session::FullMatrixSession;
+    use crate::init::singletons::NOTIFICATION_CLIENT;
+    use crate::models::notification::FrontendNotificationResult;
+
+    let mut cache = NOTIFICATION_CLIENT.lock().await;
+
+    let needs_rebuild = match cache.as_ref() {
+        None => true,
+        // The app started since this standalone client was built: switch to a
+        // client derived from the app's, dropping the standalone one.
+        Some(cached) => !cached.derived_from_main && CLIENT.get().is_some(),
+    };
+    if needs_rebuild {
+        // Drop any previous client (and its store handles) before opening a
+        // new one on the same stores.
+        *cache = None;
+        *cache = Some(build_cached_notification_client(&session).await?);
+    }
+    let cached = cache.as_ref().expect("just initialized above");
+
+    let status = cached
+        .notification_client
+        .get_notification(&room_id, &event_id)
+        .await
+        .map_err(anyhow::Error::from)?;
+    let status = map_notification_status(&cached.parent, status).await;
+
+    // The client persists across calls, so its tokens may have been refreshed
+    // at any point (during this fetch, between fetches, or — when derived from
+    // the app's client — by the app itself): report the current session back
+    // whenever it no longer matches the stored one the caller passed in.
+    let FullMatrixSession { client_session, .. } =
+        serde_json::from_str(&session).map_err(anyhow::Error::from)?;
+    let refreshed_session = cached
+        .parent
+        .session()
+        .map(|auth| serde_json::to_string(&FullMatrixSession::new(client_session, auth)))
+        .transpose()
+        .map_err(anyhow::Error::from)?
+        .filter(|current| *current != session);
+
+    Ok(FrontendNotificationResult {
+        status,
+        refreshed_session,
+    })
+}
+
+/// Build the notification client cached by the single-process (Android) path.
+async fn build_cached_notification_client(
+    session: &str,
+) -> crate::Result<crate::init::singletons::CachedNotificationClient> {
+    use crate::init::session::FullMatrixSession;
+    use crate::init::singletons::{CachedNotificationClient, SYNC_SERVICE};
+    use matrix_sdk::cross_process_lock::CrossProcessLockConfig;
+    use matrix_sdk_ui::notification_client::{NotificationClient, NotificationProcessSetup};
+    use matrix_sdk_ui::sync_service::SyncService;
+
+    if let Some(client) = CLIENT.get() {
+        // Warm: derive from the app's client — shared auth context (a single
+        // token-refresh path) and coordination with the app's own encryption
+        // sync through the sync service's permit.
+        let sync_service = SYNC_SERVICE
+            .get()
+            .ok_or(anyhow!(
+                "app client exists but its sync service isn't up yet; retry on the next push"
+            ))?
+            .clone();
+        let notification_client = NotificationClient::new(
+            client.clone(),
+            NotificationProcessSetup::SingleProcess { sync_service },
+        )
+        .await
+        .map_err(anyhow::Error::from)?;
+        info!("notification client derived from the running app's client");
+        Ok(CachedNotificationClient {
+            notification_client,
+            parent: client.clone(),
+            derived_from_main: true,
+        })
+    } else {
+        // Cold: the process was started just for this push; build the
+        // process's one client from the stored session. No cross-process lock:
+        // nothing else touches the stores while the app is down, and once the
+        // app starts this client is dropped (see the cache swap above). Do not
+        // set the CLIENT singleton: the app's own restore path owns it.
+        let FullMatrixSession {
+            client_session,
+            user_session,
+        } = serde_json::from_str(session).map_err(anyhow::Error::from)?;
+        let (client, _) = build_client(
+            None,
+            Some(client_session),
+            CrossProcessLockConfig::SingleProcess,
+        )
+        .await?;
+        client.restore_session(user_session).await?;
+        // Built but never started: it only exists to hand out the
+        // encryption-sync permit the notification client asks for in
+        // single-process mode.
+        let sync_service = Arc::new(
+            SyncService::builder(client.clone())
+                .build()
+                .await
+                .map_err(anyhow::Error::from)?,
+        );
+        let notification_client = NotificationClient::new(
+            client.clone(),
+            NotificationProcessSetup::SingleProcess { sync_service },
+        )
+        .await
+        .map_err(anyhow::Error::from)?;
+        info!("standalone notification client built (cold push process)");
+        Ok(CachedNotificationClient {
+            notification_client,
+            parent: client,
+            derived_from_main: false,
+        })
+    }
+}
+
+/// Multi-process (iOS NSE) notification resolution: fully self-contained.
+///
+/// Restores a lightweight client from the stored session on every call (the
+/// NSE process is short-lived anyway), with a cross-process store-lock holder
+/// distinct from the main app's so both processes can safely write the shared
+/// stores. Does **not** touch the CLIENT singleton, the sync service, the
+/// `StateUpdater` or the event bridge.
+async fn get_notification_item_multi_process(
+    session: String,
+    room_id: OwnedRoomId,
+    event_id: OwnedEventId,
+) -> crate::Result<crate::models::notification::FrontendNotificationResult> {
+    use crate::init::session::FullMatrixSession;
+    use crate::models::notification::FrontendNotificationResult;
+    use matrix_sdk::cross_process_lock::CrossProcessLockConfig;
+    use matrix_sdk_ui::notification_client::{NotificationClient, NotificationProcessSetup};
 
     let FullMatrixSession {
         client_session,
         user_session,
     } = serde_json::from_str(&session).map_err(anyhow::Error::from)?;
 
-    // Build a client sharing the same on-disk store as the main app, but with a
-    // distinct cross-process lock holder name. Do not set the CLIENT singleton
-    // or start any sync/worker: this client is local to this call.
-    let (client, client_session) =
-        build_client(None, Some(client_session), Some("notifications")).await?;
+    let (client, client_session) = build_client(
+        None,
+        Some(client_session),
+        CrossProcessLockConfig::multi_process("notifications"),
+    )
+    .await?;
     client.restore_session(user_session).await?;
 
     // Watch for token rotation during the notification fetch so we can hand the
@@ -539,8 +717,45 @@ pub async fn get_notification_item(
         .get_notification(&room_id, &event_id)
         .await
         .map_err(anyhow::Error::from)?;
+    let status = map_notification_status(&client, status).await;
 
-    let status = match status {
+    // Drain any session change that happened during the fetch.
+    let mut tokens_refreshed = false;
+    while let Ok(change) = session_changes.try_recv() {
+        if matches!(change, matrix_sdk::SessionChange::TokensRefreshed) {
+            tokens_refreshed = true;
+        }
+    }
+
+    let refreshed_session = if tokens_refreshed {
+        client
+            .session()
+            .map(|auth| serde_json::to_string(&FullMatrixSession::new(client_session, auth)))
+            .transpose()
+            .map_err(anyhow::Error::from)?
+    } else {
+        None
+    };
+
+    Ok(FrontendNotificationResult {
+        status,
+        refreshed_session,
+    })
+}
+
+/// Map the SDK's notification status to the serializable frontend type,
+/// fetching the sender's avatar through `client` when there is one.
+async fn map_notification_status(
+    client: &matrix_sdk::Client,
+    status: matrix_sdk_ui::notification_client::NotificationStatus,
+) -> crate::models::notification::FrontendNotificationStatus {
+    use crate::{
+        models::notification::{FrontendNotificationItem, FrontendNotificationStatus},
+        room::notifications::{event_notification_body, truncate},
+    };
+    use matrix_sdk_ui::notification_client::{NotificationEvent, NotificationStatus};
+
+    match status {
         NotificationStatus::Event(item) => {
             let item = *item;
             let sender_name = item
@@ -593,28 +808,5 @@ pub async fn get_notification_item(
         NotificationStatus::EventNotFound => FrontendNotificationStatus::NotFound,
         NotificationStatus::EventFilteredOut => FrontendNotificationStatus::FilteredOut,
         NotificationStatus::EventRedacted => FrontendNotificationStatus::Redacted,
-    };
-
-    // Drain any session change that happened during the fetch.
-    let mut tokens_refreshed = false;
-    while let Ok(change) = session_changes.try_recv() {
-        if matches!(change, matrix_sdk::SessionChange::TokensRefreshed) {
-            tokens_refreshed = true;
-        }
     }
-
-    let refreshed_session = if tokens_refreshed {
-        client
-            .session()
-            .map(|auth| serde_json::to_string(&FullMatrixSession::new(client_session, auth)))
-            .transpose()
-            .map_err(anyhow::Error::from)?
-    } else {
-        None
-    };
-
-    Ok(FrontendNotificationResult {
-        status,
-        refreshed_session,
-    })
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -743,8 +743,28 @@ async fn get_notification_item_multi_process(
     })
 }
 
+/// Fetch avatar bytes from an MXC URL through `client`. Errors are swallowed
+/// (`None`): an unavailable avatar must not fail the notification.
+async fn fetch_avatar_content(
+    client: &matrix_sdk::Client,
+    mxc_uri: Option<String>,
+) -> Option<Vec<u8>> {
+    client
+        .media()
+        .get_media_content(
+            &MediaRequestParameters {
+                source: MediaSource::Plain(OwnedMxcUri::from(mxc_uri?)),
+                format: matrix_sdk::media::MediaFormat::File,
+            },
+            true,
+        )
+        .await
+        .ok()
+}
+
 /// Map the SDK's notification status to the serializable frontend type,
-/// fetching the sender's avatar through `client` when there is one.
+/// fetching the sender's avatar (and, for group rooms, the room's avatar)
+/// through `client` when there is one.
 async fn map_notification_status(
     client: &matrix_sdk::Client,
     status: matrix_sdk_ui::notification_client::NotificationStatus,
@@ -776,20 +796,13 @@ async fn map_notification_status(
                 format!("{sender_name} in {}", item.room_computed_display_name)
             };
 
-            let sender_avatar = if let Some(mxc_uri) = item.sender_avatar_url {
-                client
-                    .media()
-                    .get_media_content(
-                        &MediaRequestParameters {
-                            source: MediaSource::Plain(OwnedMxcUri::from(mxc_uri)),
-                            format: matrix_sdk::media::MediaFormat::File,
-                        },
-                        true,
-                    )
-                    .await
-                    .ok() // We ignore the error
-            } else {
+            let sender_avatar = fetch_avatar_content(client, item.sender_avatar_url).await;
+            // Group-room notifications brand as the room (room name + room
+            // avatar), so fetch its avatar too; DMs render the sender's only.
+            let room_avatar = if item.is_direct_message_room {
                 None
+            } else {
+                fetch_avatar_content(client, item.room_avatar_url.clone()).await
             };
 
             FrontendNotificationStatus::Event(FrontendNotificationItem {
@@ -797,6 +810,7 @@ async fn map_notification_status(
                 body,
                 sender_display_name: item.sender_display_name,
                 sender_avatar,
+                room_avatar,
                 room_display_name: item.room_computed_display_name,
                 room_avatar_url: item.room_avatar_url,
                 is_dm: item.is_direct_message_room,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -32,7 +32,7 @@ use matrix_sdk_ui::timeline::{AttachmentConfig, AttachmentSource};
 use mime::Mime;
 use rand::{RngExt, distr::Alphanumeric, rng};
 use std::{sync::Arc, time::Duration};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use url::Url;
 
 pub use crate::room::preview::SerializableRoomPreview;
@@ -490,6 +490,11 @@ pub enum NotificationProcessMode {
     /// The push handler runs in a dedicated short-lived process — the iOS
     /// Notification Service Extension. A standalone client with a distinct
     /// cross-process store-lock holder is built on each call.
+    ///
+    /// **iOS only**: the main client takes part in the cross-process store
+    /// lock only on iOS (see `main_client_lock_config`). Using this mode on
+    /// another platform would leave the shared crypto store unsynchronized
+    /// between the two processes.
     MultipleProcesses,
 }
 
@@ -504,9 +509,9 @@ pub enum NotificationProcessMode {
 /// * `mode` — see [`NotificationProcessMode`]; pick by platform.
 ///
 /// If the access/refresh tokens were rotated while resolving the notification,
-/// the returned [`FrontendNotificationResult::refreshed_session`] holds an
-/// updated serialized session that the caller must persist.
-// #[cfg(any(target_os = "android", target_os = "ios"))]
+/// the returned
+/// [`refreshed_session`](crate::models::notification::FrontendNotificationResult::refreshed_session)
+/// holds an updated serialized session that the caller must persist.
 pub async fn get_notification_item(
     session: String,
     app_data_dir: std::path::PathBuf,
@@ -514,14 +519,21 @@ pub async fn get_notification_item(
     event_id: OwnedEventId,
     mode: NotificationProcessMode,
 ) -> crate::Result<crate::models::notification::FrontendNotificationResult> {
-    use crate::init::singletons::{APP_DATA_DIR, RUNTIME_HANDLE};
+    use crate::init::singletons::{RUNTIME_HANDLE, set_or_verify_app_data_dir};
 
     // A push-only (cold) process is fresh, so APP_DATA_DIR is unset;
-    // `build_client` waits on it. Ignore the error in case it was already set.
-    let _ = APP_DATA_DIR.set(app_data_dir);
+    // `build_client` waits on it. A repeated set of the same dir is fine; a
+    // conflicting one is an adapter misconfiguration and must fail loudly.
+    set_or_verify_app_data_dir(app_data_dir)?;
 
     match mode {
         NotificationProcessMode::MultipleProcesses => {
+            if !cfg!(target_os = "ios") {
+                warn!(
+                    "NotificationProcessMode::MultipleProcesses is only sound on iOS: \
+                     the main client only takes part in the cross-process store lock there"
+                );
+            }
             get_notification_item_multi_process(session, room_id, event_id).await
         }
         NotificationProcessMode::SingleProcess => {
@@ -529,12 +541,23 @@ pub async fn get_notification_item(
             // caller may be on a short-lived runtime (the Android JNI entry),
             // and tasks the SDK spawns mid-call must outlive that caller.
             if let Some(handle) = RUNTIME_HANDLE.get() {
-                handle
+                match handle
                     .spawn(get_notification_item_single_process(
-                        session, room_id, event_id,
+                        session.clone(),
+                        room_id.clone(),
+                        event_id.clone(),
                     ))
                     .await
-                    .map_err(anyhow::Error::from)?
+                {
+                    Ok(result) => result,
+                    // The runtime that ran init() has shut down but the
+                    // process (and this handle) survived: run inline on the
+                    // caller's runtime instead of failing every push.
+                    Err(e) if e.is_cancelled() => {
+                        get_notification_item_single_process(session, room_id, event_id).await
+                    }
+                    Err(e) => Err(anyhow::Error::from(e).into()),
+                }
             } else {
                 get_notification_item_single_process(session, room_id, event_id).await
             }
@@ -554,51 +577,43 @@ async fn get_notification_item_single_process(
     room_id: OwnedRoomId,
     event_id: OwnedEventId,
 ) -> crate::Result<crate::models::notification::FrontendNotificationResult> {
-    use crate::init::session::FullMatrixSession;
-    use crate::init::singletons::NOTIFICATION_CLIENT;
-    use crate::models::notification::FrontendNotificationResult;
+    use crate::init::singletons::{NOTIFICATION_CLIENT, SYNC_SERVICE};
 
     let mut cache = NOTIFICATION_CLIENT.lock().await;
 
+    // Only swap a standalone client for an app-derived one once the derived
+    // build can actually succeed (client *and* sync service up); in the app's
+    // startup window between the two, keep resolving with the standalone one.
+    let can_derive = CLIENT.get().is_some() && SYNC_SERVICE.get().is_some();
     let needs_rebuild = match cache.as_ref() {
         None => true,
-        // The app started since this standalone client was built: switch to a
-        // client derived from the app's, dropping the standalone one.
-        Some(cached) => !cached.derived_from_main && CLIENT.get().is_some(),
+        Some(cached) => !cached.derived_from_main && can_derive,
     };
     if needs_rebuild {
-        // Drop any previous client (and its store handles) before opening a
-        // new one on the same stores.
-        *cache = None;
-        *cache = Some(build_cached_notification_client(&session).await?);
+        // Build first, swap after: on failure a still-working standalone
+        // client keeps resolving pushes. Safe ordering — the derived build
+        // opens no new stores, so the old entry may briefly outlive it.
+        match build_cached_notification_client(&session).await {
+            Ok(new) => *cache = Some(new),
+            Err(e) if cache.is_some() => {
+                warn!(
+                    "Failed to switch to an app-derived notification client, \
+                     keeping the standalone one: {e}"
+                );
+            }
+            Err(e) => return Err(e),
+        }
     }
     let cached = cache.as_ref().expect("just initialized above");
 
-    let status = cached
-        .notification_client
-        .get_notification(&room_id, &event_id)
-        .await
-        .map_err(anyhow::Error::from)?;
-    let status = map_notification_status(&cached.parent, status).await;
-
-    // The client persists across calls, so its tokens may have been refreshed
-    // at any point (during this fetch, between fetches, or — when derived from
-    // the app's client — by the app itself): report the current session back
-    // whenever it no longer matches the stored one the caller passed in.
-    let FullMatrixSession { client_session, .. } =
-        serde_json::from_str(&session).map_err(anyhow::Error::from)?;
-    let refreshed_session = cached
-        .parent
-        .session()
-        .map(|auth| serde_json::to_string(&FullMatrixSession::new(client_session, auth)))
-        .transpose()
-        .map_err(anyhow::Error::from)?
-        .filter(|current| *current != session);
-
-    Ok(FrontendNotificationResult {
-        status,
-        refreshed_session,
-    })
+    resolve_notification(
+        &cached.parent,
+        &cached.notification_client,
+        &session,
+        &room_id,
+        &event_id,
+    )
+    .await
 }
 
 /// Build the notification client cached by the single-process (Android) path.
@@ -636,20 +651,13 @@ async fn build_cached_notification_client(
     } else {
         // Cold: the process was started just for this push; build the
         // process's one client from the stored session. No cross-process lock:
-        // nothing else touches the stores while the app is down, and once the
-        // app starts this client is dropped (see the cache swap above). Do not
-        // set the CLIENT singleton: the app's own restore path owns it.
-        let FullMatrixSession {
-            client_session,
-            user_session,
-        } = serde_json::from_str(session).map_err(anyhow::Error::from)?;
-        let (client, _) = build_client(
-            None,
-            Some(client_session),
-            CrossProcessLockConfig::SingleProcess,
-        )
-        .await?;
-        client.restore_session(user_session).await?;
+        // nothing else touches the stores while the app is down, and the app's
+        // restore path drops this client before opening the same stores. Do
+        // not set the CLIENT singleton: the app's own restore path owns it.
+        let full: FullMatrixSession = serde_json::from_str(session).map_err(anyhow::Error::from)?;
+        let (client, _) =
+            crate::init::session::restore_client(full, CrossProcessLockConfig::SingleProcess)
+                .await?;
         // Built but never started: it only exists to hand out the
         // encryption-sync permit the notification client asks for in
         // single-process mode.
@@ -687,55 +695,59 @@ async fn get_notification_item_multi_process(
     event_id: OwnedEventId,
 ) -> crate::Result<crate::models::notification::FrontendNotificationResult> {
     use crate::init::session::FullMatrixSession;
-    use crate::models::notification::FrontendNotificationResult;
     use matrix_sdk::cross_process_lock::CrossProcessLockConfig;
     use matrix_sdk_ui::notification_client::{NotificationClient, NotificationProcessSetup};
 
-    let FullMatrixSession {
-        client_session,
-        user_session,
-    } = serde_json::from_str(&session).map_err(anyhow::Error::from)?;
+    // iOS runs several `didReceive` calls concurrently in one NSE process, and
+    // each call builds its own client with the *same* store-lock holder name —
+    // same-holder acquisitions are reentrant, so the cross-process lock cannot
+    // exclude those clients from each other. Serialize the calls instead.
+    static NSE_GUARD: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+    let _guard = NSE_GUARD.lock().await;
 
-    let (client, client_session) = build_client(
-        None,
-        Some(client_session),
-        CrossProcessLockConfig::multi_process("notifications"),
-    )
-    .await?;
-    client.restore_session(user_session).await?;
-
-    // Watch for token rotation during the notification fetch so we can hand the
-    // refreshed session back to the caller for persistence.
-    let mut session_changes = client.subscribe_to_session_changes();
+    let full: FullMatrixSession = serde_json::from_str(&session).map_err(anyhow::Error::from)?;
+    // Holder name distinct from both the main app's ("main") and the one the
+    // SDK's notification client takes internally ("notifications").
+    let (client, _) =
+        crate::init::session::restore_client(full, CrossProcessLockConfig::multi_process("nse"))
+            .await?;
 
     let notification_client =
         NotificationClient::new(client.clone(), NotificationProcessSetup::MultipleProcesses)
             .await
             .map_err(anyhow::Error::from)?;
 
+    resolve_notification(&client, &notification_client, &session, &room_id, &event_id).await
+}
+
+/// Shared tail of both notification paths: fetch and map the notification,
+/// then report the current session back whenever it no longer matches the
+/// stored one the caller passed in — the tokens may have been refreshed at any
+/// point (during this fetch, between fetches, or by the app itself).
+async fn resolve_notification(
+    client: &matrix_sdk::Client,
+    notification_client: &matrix_sdk_ui::notification_client::NotificationClient,
+    session: &str,
+    room_id: &OwnedRoomId,
+    event_id: &OwnedEventId,
+) -> crate::Result<crate::models::notification::FrontendNotificationResult> {
+    use crate::init::session::FullMatrixSession;
+    use crate::models::notification::FrontendNotificationResult;
+
     let status = notification_client
-        .get_notification(&room_id, &event_id)
+        .get_notification(room_id, event_id)
         .await
         .map_err(anyhow::Error::from)?;
-    let status = map_notification_status(&client, status).await;
+    let status = map_notification_status(client, status).await;
 
-    // Drain any session change that happened during the fetch.
-    let mut tokens_refreshed = false;
-    while let Ok(change) = session_changes.try_recv() {
-        if matches!(change, matrix_sdk::SessionChange::TokensRefreshed) {
-            tokens_refreshed = true;
-        }
-    }
-
-    let refreshed_session = if tokens_refreshed {
-        client
-            .session()
-            .map(|auth| serde_json::to_string(&FullMatrixSession::new(client_session, auth)))
-            .transpose()
-            .map_err(anyhow::Error::from)?
-    } else {
-        None
-    };
+    let FullMatrixSession { client_session, .. } =
+        serde_json::from_str(session).map_err(anyhow::Error::from)?;
+    let refreshed_session = client
+        .session()
+        .map(|auth| serde_json::to_string(&FullMatrixSession::new(client_session, auth)))
+        .transpose()
+        .map_err(anyhow::Error::from)?
+        .filter(|current| current.as_str() != session);
 
     Ok(FrontendNotificationResult {
         status,
@@ -747,14 +759,22 @@ async fn get_notification_item_multi_process(
 /// (`None`): an unavailable avatar must not fail the notification.
 async fn fetch_avatar_content(
     client: &matrix_sdk::Client,
-    mxc_uri: Option<String>,
+    mxc_uri: Option<&str>,
 ) -> Option<Vec<u8>> {
+    use matrix_sdk::media::{MediaFormat, MediaThumbnailSettings};
+
     client
         .media()
         .get_media_content(
             &MediaRequestParameters {
                 source: MediaSource::Plain(OwnedMxcUri::from(mxc_uri?)),
-                format: matrix_sdk::media::MediaFormat::File,
+                // Notification avatars render tiny; a thumbnail caps the
+                // download where the original file is unbounded — this runs
+                // inside time-budgeted background push handlers.
+                format: MediaFormat::Thumbnail(MediaThumbnailSettings::new(
+                    UInt::from(96u32),
+                    UInt::from(96u32),
+                )),
             },
             true,
         )
@@ -796,13 +816,14 @@ async fn map_notification_status(
                 format!("{sender_name} in {}", item.room_computed_display_name)
             };
 
-            let sender_avatar = fetch_avatar_content(client, item.sender_avatar_url).await;
+            let sender_avatar =
+                fetch_avatar_content(client, item.sender_avatar_url.as_deref()).await;
             // Group-room notifications brand as the room (room name + room
             // avatar), so fetch its avatar too; DMs render the sender's only.
             let room_avatar = if item.is_direct_message_room {
                 None
             } else {
-                fetch_avatar_content(client, item.room_avatar_url.clone()).await
+                fetch_avatar_content(client, item.room_avatar_url.as_deref()).await
             };
 
             FrontendNotificationStatus::Event(FrontendNotificationItem {

--- a/src/init/login.rs
+++ b/src/init/login.rs
@@ -56,10 +56,25 @@ pub(crate) async fn login_and_persist_matrix_session(
     Ok(serialized)
 }
 
+/// The store-lock configuration for the app's main client.
+///
+/// On iOS the Notification Service Extension is a genuinely separate process
+/// writing the same stores, so the main client must take part in the
+/// cross-process lock. Everywhere else (Android included: the FCM service and
+/// the JNI cold-push entry run inside the app's own process) the app is the
+/// only process touching the stores, so no cross-process lock is needed.
+pub(crate) fn main_client_lock_config() -> CrossProcessLockConfig {
+    if cfg!(target_os = "ios") {
+        CrossProcessLockConfig::multi_process("main")
+    } else {
+        CrossProcessLockConfig::SingleProcess
+    }
+}
+
 pub async fn build_client(
     homeserver_opt: Option<String>,
     client_session: Option<ClientSession>,
-    cross_process_holder: Option<&str>,
+    cross_process_lock_config: CrossProcessLockConfig,
 ) -> anyhow::Result<(Client, ClientSession)> {
     let (homeserver, db_path, passphrase, db_identifier) = match client_session {
         Some(s) => {
@@ -97,7 +112,7 @@ pub async fn build_client(
         }
     };
 
-    let mut builder = Client::builder()
+    let builder = Client::builder()
         .server_name_or_homeserver_url(homeserver.clone())
         .with_threading_support(ThreadingSupport::Enabled {
             with_subscriptions: false,
@@ -111,15 +126,14 @@ pub async fn build_client(
         })
         .with_enable_share_history_on_invite(true)
         .handle_refresh_tokens()
-        .request_config(RequestConfig::new().timeout(std::time::Duration::from_secs(60)));
-
-    // When the client runs in a separate process (e.g. the mobile notification
-    // service that decrypts a single push event), it must use a cross-process
-    // store lock holder name distinct from the main app's default ("main"),
-    // otherwise concurrent writes to the shared crypto store can collide.
-    if let Some(holder) = cross_process_holder {
-        builder = builder.cross_process_store_config(CrossProcessLockConfig::multi_process(holder));
-    }
+        .request_config(RequestConfig::new().timeout(std::time::Duration::from_secs(60)))
+        // Always set explicitly: the builder's implicit default is
+        // `multi_process("main")`, which is only right for the iOS main app
+        // (see `main_client_lock_config`). When the client runs in a separate
+        // process (the iOS NSE decrypting a push), it must use a holder name
+        // distinct from the main app's "main", otherwise concurrent writes to
+        // the shared crypto store can collide.
+        .cross_process_store_config(cross_process_lock_config);
 
     let client = builder.build().await?;
 

--- a/src/init/login.rs
+++ b/src/init/login.rs
@@ -3,6 +3,7 @@ use matrix_sdk::{
     Client, ThreadingSupport, config::RequestConfig, encryption::EncryptionSettings,
     sliding_sync::VersionBuilder,
 };
+use matrix_sdk::cross_process_lock::CrossProcessLockConfig;
 
 use rand::{RngExt, distr::Alphanumeric, rng};
 
@@ -58,6 +59,7 @@ pub(crate) async fn login_and_persist_matrix_session(
 pub async fn build_client(
     homeserver_opt: Option<String>,
     client_session: Option<ClientSession>,
+    cross_process_holder: Option<&str>,
 ) -> anyhow::Result<(Client, ClientSession)> {
     let (homeserver, db_path, passphrase, db_identifier) = match client_session {
         Some(s) => {
@@ -95,7 +97,7 @@ pub async fn build_client(
         }
     };
 
-    let client = Client::builder()
+    let mut builder = Client::builder()
         .server_name_or_homeserver_url(homeserver.clone())
         .with_threading_support(ThreadingSupport::Enabled {
             with_subscriptions: false,
@@ -109,9 +111,17 @@ pub async fn build_client(
         })
         .with_enable_share_history_on_invite(true)
         .handle_refresh_tokens()
-        .request_config(RequestConfig::new().timeout(std::time::Duration::from_secs(60)))
-        .build()
-        .await?;
+        .request_config(RequestConfig::new().timeout(std::time::Duration::from_secs(60)));
+
+    // When the client runs in a separate process (e.g. the mobile notification
+    // service that decrypts a single push event), it must use a cross-process
+    // store lock holder name distinct from the main app's default ("main"),
+    // otherwise concurrent writes to the shared crypto store can collide.
+    if let Some(holder) = cross_process_holder {
+        builder = builder.cross_process_store_config(CrossProcessLockConfig::multi_process(holder));
+    }
+
+    let client = builder.build().await?;
 
     add_event_handlers(&client);
 

--- a/src/init/login.rs
+++ b/src/init/login.rs
@@ -1,9 +1,9 @@
 use anyhow::anyhow;
+use matrix_sdk::cross_process_lock::CrossProcessLockConfig;
 use matrix_sdk::{
     Client, ThreadingSupport, config::RequestConfig, encryption::EncryptionSettings,
     sliding_sync::VersionBuilder,
 };
-use matrix_sdk::cross_process_lock::CrossProcessLockConfig;
 
 use rand::{RngExt, distr::Alphanumeric, rng};
 
@@ -63,6 +63,12 @@ pub(crate) async fn login_and_persist_matrix_session(
 /// cross-process lock. Everywhere else (Android included: the FCM service and
 /// the JNI cold-push entry run inside the app's own process) the app is the
 /// only process touching the stores, so no cross-process lock is needed.
+///
+/// **Constraint**: because the main client only participates in the lock on
+/// iOS, [`crate::commands::NotificationProcessMode::MultipleProcesses`] is only
+/// sound on iOS. An adapter that runs its push handler in a genuinely separate
+/// process on another platform (e.g. an Android `:push` process) would write
+/// the shared crypto store unsynchronized — that setup is unsupported.
 pub(crate) fn main_client_lock_config() -> CrossProcessLockConfig {
     if cfg!(target_os = "ios") {
         CrossProcessLockConfig::multi_process("main")
@@ -112,6 +118,11 @@ pub async fn build_client(
         }
     };
 
+    let refresh_lock_holder = match &cross_process_lock_config {
+        CrossProcessLockConfig::MultiProcess { holder_name } => Some(holder_name.clone()),
+        _ => None,
+    };
+
     let builder = Client::builder()
         .server_name_or_homeserver_url(homeserver.clone())
         .with_threading_support(ThreadingSupport::Enabled {
@@ -136,6 +147,18 @@ pub async fn build_client(
         .cross_process_store_config(cross_process_lock_config);
 
     let client = builder.build().await?;
+
+    // When several processes share these stores (iOS app + NSE), OAuth token
+    // refreshes must also be coordinated: without this lock each process
+    // refreshes independently, and with rotating refresh tokens (MAS default)
+    // one process's refresh invalidates the other's token, forcing a logout.
+    // Deferred by the SDK until session restore; no-op for password auth.
+    if let Some(holder_name) = refresh_lock_holder {
+        client
+            .oauth()
+            .enable_cross_process_refresh_lock(holder_name)
+            .await?;
+    }
 
     add_event_handlers(&client);
 

--- a/src/init/session.rs
+++ b/src/init/session.rs
@@ -126,7 +126,7 @@ pub async fn restore_client_from_session(session: FullMatrixSession) -> anyhow::
         user_session,
     } = session;
 
-    let (client, _) = build_client(None, Some(client_session)).await?;
+    let (client, _) = build_client(None, Some(client_session), None).await?;
 
     client.restore_session(user_session).await?;
 

--- a/src/init/session.rs
+++ b/src/init/session.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use crate::{
     init::{
         login::build_client,
-        singletons::{CLIENT, HAS_SESSION_STORED},
+        singletons::{CLIENT, HAS_SESSION_STORED, NOTIFICATION_CLIENT},
     },
     models::{
         events::{ToastNotificationRequest, ToastNotificationVariant},
@@ -120,20 +120,34 @@ impl FullMatrixSession {
     }
 }
 
-pub async fn restore_client_from_session(session: FullMatrixSession) -> anyhow::Result<Client> {
+/// Build a client from a stored session and restore that session on it, with
+/// the given store-lock configuration. Shared by the app's own restore path and
+/// the background push-notification paths; does not touch any singleton.
+pub(crate) async fn restore_client(
+    session: FullMatrixSession,
+    lock_config: matrix_sdk::cross_process_lock::CrossProcessLockConfig,
+) -> anyhow::Result<(Client, ClientSession)> {
     let FullMatrixSession {
         client_session,
         user_session,
     } = session;
 
-    let (client, _) = build_client(
-        None,
-        Some(client_session),
-        crate::init::login::main_client_lock_config(),
-    )
-    .await?;
+    let (client, client_session) = build_client(None, Some(client_session), lock_config).await?;
 
     client.restore_session(user_session).await?;
+
+    Ok((client, client_session))
+}
+
+pub async fn restore_client_from_session(session: FullMatrixSession) -> anyhow::Result<Client> {
+    // Drop any standalone notification client a cold push built before the app
+    // started. The cache mutex spans a whole notification fetch, so this also
+    // waits for an in-flight fetch to finish and closes its store handles
+    // before the app's client reopens the same stores.
+    *NOTIFICATION_CLIENT.lock().await = None;
+
+    let (client, _) =
+        restore_client(session, crate::init::login::main_client_lock_config()).await?;
 
     CLIENT
         .set(client.clone())

--- a/src/init/session.rs
+++ b/src/init/session.rs
@@ -126,7 +126,12 @@ pub async fn restore_client_from_session(session: FullMatrixSession) -> anyhow::
         user_session,
     } = session;
 
-    let (client, _) = build_client(None, Some(client_session), None).await?;
+    let (client, _) = build_client(
+        None,
+        Some(client_session),
+        crate::init::login::main_client_lock_config(),
+    )
+    .await?;
 
     client.restore_session(user_session).await?;
 

--- a/src/init/singletons.rs
+++ b/src/init/singletons.rs
@@ -10,7 +10,7 @@ use matrix_sdk::{
     Client, RoomMemberships,
     ruma::{OwnedRoomId, OwnedUserId},
 };
-use matrix_sdk_ui::sync_service::SyncService;
+use matrix_sdk_ui::{notification_client::NotificationClient, sync_service::SyncService};
 use tokio::{
     sync::{
         broadcast,
@@ -33,8 +33,35 @@ use crate::{
 /// Currently there is only one, but it can be cloned if we need more concurrent senders.
 pub static REQUEST_SENDER: OnceLock<UnboundedSender<MatrixRequest>> = OnceLock::new();
 
-/// The singleton sync service.
-pub static SYNC_SERVICE: OnceLock<SyncService> = OnceLock::new();
+/// The singleton sync service. `Arc`'d because
+/// [`matrix_sdk_ui::notification_client::NotificationProcessSetup::SingleProcess`]
+/// needs a shared handle to it.
+pub static SYNC_SERVICE: OnceLock<Arc<SyncService>> = OnceLock::new();
+
+/// Handle to the tokio runtime [`crate::init`] ran on. Background push entry
+/// points (the Android JNI silent-push path) run on their own short-lived
+/// runtime; anything touching [`CLIENT`] must be spawned onto this runtime
+/// instead, so tasks the SDK spawns mid-call survive the caller's runtime.
+/// Unset when the app never started in this process (cold push process).
+pub static RUNTIME_HANDLE: OnceLock<tokio::runtime::Handle> = OnceLock::new();
+
+/// A notification client kept alive across push notifications, so repeated
+/// pushes don't rebuild a client (and reopen the stores) each time.
+pub(crate) struct CachedNotificationClient {
+    pub(crate) notification_client: NotificationClient,
+    /// The client the notification client was derived from; used for follow-up
+    /// requests (e.g. fetching the sender's avatar).
+    pub(crate) parent: Client,
+    /// `true` when `parent` is the global [`CLIENT`]. `false` for a standalone
+    /// client built in a push-only (cold) process; such a cache entry is
+    /// replaced as soon as [`CLIENT`] exists.
+    pub(crate) derived_from_main: bool,
+}
+
+/// Cache for the single-process notification path. The mutex is held across
+/// the whole fetch, which also serializes concurrent pushes.
+pub(crate) static NOTIFICATION_CLIENT: tokio::sync::Mutex<Option<CachedNotificationClient>> =
+    tokio::sync::Mutex::const_new(None);
 
 /// Flag set by `handle_rooms_loading_state` when all rooms are loaded.
 /// if rooms have been synced or not.

--- a/src/init/singletons.rs
+++ b/src/init/singletons.rs
@@ -108,6 +108,24 @@ pub struct GlobalBroadcaster {
 
 pub static APP_DATA_DIR: OnceLock<PathBuf> = OnceLock::new();
 
+/// Set [`APP_DATA_DIR`], tolerating a repeated set of the *same* path (the
+/// Android push entry point and `init()` both supply it, in either order) but
+/// failing loudly on a conflicting one: silently keeping the first path would
+/// open the sqlite/crypto stores under the wrong directory with no diagnostics.
+pub(crate) fn set_or_verify_app_data_dir(path: PathBuf) -> anyhow::Result<()> {
+    if let Err(rejected) = APP_DATA_DIR.set(path) {
+        let existing = APP_DATA_DIR.get().expect("APP_DATA_DIR set() just failed");
+        if *existing != rejected {
+            return Err(anyhow!(
+                "APP_DATA_DIR mismatch: already set to {} but now given {}",
+                existing.display(),
+                rejected.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
 impl GlobalBroadcaster {
     fn new(capacity: usize) -> Self {
         let (sender, _) = broadcast::channel(capacity);

--- a/src/init/sync.rs
+++ b/src/init/sync.rs
@@ -28,10 +28,12 @@ pub async fn sync(
     client: Client,
     state_updaters: Arc<Box<dyn StateUpdater>>,
 ) -> anyhow::Result<()> {
-    let sync_service = SyncService::builder(client)
-        .with_offline_mode()
-        .build()
-        .await?;
+    let sync_service = Arc::new(
+        SyncService::builder(client)
+            .with_offline_mode()
+            .build()
+            .await?,
+    );
 
     // Start the sync service
     sync_service.start().await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,6 +419,9 @@ pub use events::timeline::{PaginationDirection, TimelineKind};
 pub use init::session::FullMatrixSession;
 pub use init::singletons::{CLIENT, LOGIN_STORE_READY};
 pub use models::async_requests::*;
+pub use models::notification::{
+    FrontendNotificationItem, FrontendNotificationResult, FrontendNotificationStatus,
+};
 pub use room::frontend_events::events_dto::FrontendTimelineItem;
 pub use room::room_screen::RoomScreen;
 pub use room::rooms_list::RoomsList;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -444,7 +444,7 @@ pub use matrix_sdk::encryption::recovery::RecoveryState;
 pub use matrix_sdk::media::{MediaFormat, MediaRequestParameters, MediaThumbnailSettings};
 pub use matrix_sdk::ruma::serde::base64::{Base64, Standard, UrlSafe};
 pub use matrix_sdk::ruma::{
-    OwnedDeviceId, OwnedMxcUri, OwnedRoomId, OwnedUserId, UInt,
+    OwnedDeviceId, OwnedMxcUri, OwnedRoomId, OwnedUserId, RoomId, UInt,
     events::room::{
         EncryptedFile, EncryptedFileHashes, EncryptedFileInfo, MediaSource, V2EncryptedFileInfo,
     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use crate::{
         FrontendAuthTypeResponse, check_homeserver_auth_type,
         session::{setup_token_background_save, try_restore_session_to_state},
         singletons::{
-            APP_DATA_DIR, CURRENT_USER_ID, EVENT_BRIDGE, REQUEST_SENDER, RUNTIME_HANDLE,
+            CURRENT_USER_ID, EVENT_BRIDGE, REQUEST_SENDER, RUNTIME_HANDLE,
             VERIFICATION_RESPONSE_RECEIVER,
         },
         workers::{async_main_loop, async_worker},
@@ -133,10 +133,11 @@ impl LibConfig {
 /// This will start the workers and return a `Receiver` to forward outgoing events.
 pub fn init(mut config: LibConfig) -> broadcast::Receiver<EmitEvent> {
     // On Android the silent-push (cold) notification path may already have set
-    // `APP_DATA_DIR` to the same value if this process previously handled a push
-    // and is now being reused to launch the app. Tolerate that instead of
-    // panicking (it is the identical data dir). See `get_notification_item`.
-    let _ = APP_DATA_DIR.set(config.app_data_dir);
+    // `APP_DATA_DIR` if this process previously handled a push and is now being
+    // reused to launch the app. Tolerate a repeated set of the same dir, but
+    // fail loudly on a conflicting one. See `get_notification_item`.
+    init::singletons::set_or_verify_app_data_dir(config.app_data_dir)
+        .expect("init() was given a different app data dir than the push entry point");
 
     // Remember the runtime the lib runs on so background push entry points
     // (which arrive on their own short-lived runtime) can hop onto it. See

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,9 +132,11 @@ impl LibConfig {
 /// Function to be called once your app is starting to init this lib.
 /// This will start the workers and return a `Receiver` to forward outgoing events.
 pub fn init(mut config: LibConfig) -> broadcast::Receiver<EmitEvent> {
-    APP_DATA_DIR
-        .set(config.app_data_dir)
-        .expect("Couldn't set app data dir");
+    // On Android the silent-push (cold) notification path may already have set
+    // `APP_DATA_DIR` to the same value if this process previously handled a push
+    // and is now being reused to launch the app. Tolerate that instead of
+    // panicking (it is the identical data dir). See `get_notification_item`.
+    let _ = APP_DATA_DIR.set(config.app_data_dir);
 
     // Lib -> adapter events
     let (event_bridge, broadcast_receiver) = EventBridge::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use crate::{
         FrontendAuthTypeResponse, check_homeserver_auth_type,
         session::{setup_token_background_save, try_restore_session_to_state},
         singletons::{
-            APP_DATA_DIR, CURRENT_USER_ID, EVENT_BRIDGE, REQUEST_SENDER,
+            APP_DATA_DIR, CURRENT_USER_ID, EVENT_BRIDGE, REQUEST_SENDER, RUNTIME_HANDLE,
             VERIFICATION_RESPONSE_RECEIVER,
         },
         workers::{async_main_loop, async_worker},
@@ -137,6 +137,11 @@ pub fn init(mut config: LibConfig) -> broadcast::Receiver<EmitEvent> {
     // and is now being reused to launch the app. Tolerate that instead of
     // panicking (it is the identical data dir). See `get_notification_item`.
     let _ = APP_DATA_DIR.set(config.app_data_dir);
+
+    // Remember the runtime the lib runs on so background push entry points
+    // (which arrive on their own short-lived runtime) can hop onto it. See
+    // `get_notification_item`.
+    let _ = RUNTIME_HANDLE.set(Handle::current());
 
     // Lib -> adapter events
     let (event_bridge, broadcast_receiver) = EventBridge::new();
@@ -417,6 +422,7 @@ pub fn init(mut config: LibConfig) -> broadcast::Receiver<EmitEvent> {
 
 // Re-exports
 
+pub use commands::NotificationProcessMode;
 pub use events::timeline::{PaginationDirection, TimelineKind};
 pub use init::session::FullMatrixSession;
 pub use init::singletons::{CLIENT, LOGIN_STORE_READY};

--- a/src/models/events.rs
+++ b/src/models/events.rs
@@ -47,6 +47,12 @@ pub enum EmitEvent {
     ResetCrossSigngingUrl(String),
     NewlyCreatedRoomId(OwnedRoomId),
     MatrixUriIntent(MatrixUriIntent),
+    /// A joined room has no unread messages left (it was read on this or
+    /// another device): the embedder can dismiss any OS notification it posted
+    /// for that room. Also emitted for every already-read room when the rooms
+    /// list is first populated, so stale notifications for rooms read while
+    /// the app was down get dismissed too — dismissals must be idempotent.
+    RoomFullyRead(OwnedRoomId),
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -5,6 +5,7 @@ pub mod event_bridge;
 pub mod events;
 pub mod matrix_uri;
 pub mod misc;
+pub mod notification;
 pub mod profile;
 pub(crate) mod room_display_name;
 pub mod state_updater;

--- a/src/models/notification.rs
+++ b/src/models/notification.rs
@@ -26,6 +26,10 @@ pub enum FrontendNotificationStatus {
     FilteredOut,
     /// The event was redacted and has no meaningful content.
     Redacted,
+    /// When no session has been found to decrypt this notification
+    InvalidSession,
+    /// The received payload has not been parsed correctly
+    WrongPayload,
 }
 
 /// The full result returned by [`crate::commands::get_notification_item`].
@@ -53,8 +57,8 @@ pub struct FrontendNotificationItem {
     pub body: Option<String>,
     /// Display name of the sender, if known.
     pub sender_display_name: Option<String>,
-    /// MXC URL of the sender's avatar, if any.
-    pub sender_avatar_url: Option<String>,
+    /// Sender's avatar buffer, if any.
+    pub sender_avatar: Option<Vec<u8>>,
     /// Computed display name of the room.
     pub room_display_name: String,
     /// MXC URL of the room's avatar, if any.

--- a/src/models/notification.rs
+++ b/src/models/notification.rs
@@ -59,6 +59,10 @@ pub struct FrontendNotificationItem {
     pub sender_display_name: Option<String>,
     /// Sender's avatar buffer, if any.
     pub sender_avatar: Option<Vec<u8>>,
+    /// Room's avatar buffer, if any. Only fetched for group rooms (`is_dm ==
+    /// false`), where the notification brands as the room rather than the
+    /// sender; DM notifications use `sender_avatar`.
+    pub room_avatar: Option<Vec<u8>>,
     /// Computed display name of the room.
     pub room_display_name: String,
     /// MXC URL of the room's avatar, if any.

--- a/src/models/notification.rs
+++ b/src/models/notification.rs
@@ -1,0 +1,72 @@
+//! Serializable result types for the background push-notification decryption
+//! flow (see [`crate::commands::get_notification_item`]).
+//!
+//! These mirror [`matrix_sdk_ui::notification_client::NotificationStatus`] /
+//! `NotificationItem`, but only keep the fields a frontend needs to render an
+//! OS notification, and are `Serialize`/`Deserialize` so a native (no-webview)
+//! caller can pass them around freely.
+
+use matrix_sdk::ruma::OwnedEventId;
+use serde::{Deserialize, Serialize};
+
+/// The outcome of resolving a single push notification.
+///
+/// Mirrors [`matrix_sdk_ui::notification_client::NotificationStatus`] so the
+/// caller can decide whether to display the notification, suppress it, or show
+/// a generic placeholder.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "camelCase")]
+pub enum FrontendNotificationStatus {
+    /// The event was found and decrypted; display this notification.
+    Event(FrontendNotificationItem),
+    /// The event couldn't be found by the network queries.
+    NotFound,
+    /// The event was filtered out by the user's push rules or because its
+    /// sender is ignored; do not notify.
+    FilteredOut,
+    /// The event was redacted and has no meaningful content.
+    Redacted,
+}
+
+/// The full result returned by [`crate::commands::get_notification_item`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrontendNotificationResult {
+    /// The resolved notification status.
+    pub status: FrontendNotificationStatus,
+    /// A re-serialized `FullMatrixSession` when the access/refresh tokens were
+    /// rotated while resolving the notification. When `Some`, persist it to the
+    /// same storage the main app reads so both processes stay in sync.
+    /// `None` when the tokens were unchanged.
+    pub refreshed_session: Option<String>,
+}
+
+/// The decrypted, display-ready content of a single notification.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrontendNotificationItem {
+    /// Title line, e.g. the sender name, or `"{sender} in {room}"` for
+    /// non-DM rooms.
+    pub summary: String,
+    /// Notification body (message preview). `None` when the event has no
+    /// displayable textual content.
+    pub body: Option<String>,
+    /// Display name of the sender, if known.
+    pub sender_display_name: Option<String>,
+    /// MXC URL of the sender's avatar, if any.
+    pub sender_avatar_url: Option<String>,
+    /// Computed display name of the room.
+    pub room_display_name: String,
+    /// MXC URL of the room's avatar, if any.
+    pub room_avatar_url: Option<String>,
+    /// Whether the room is a direct message.
+    pub is_dm: bool,
+    /// Whether the notification is "noisy" (a push action requests a sound).
+    /// `None` when the push actions couldn't be determined.
+    pub is_noisy: Option<bool>,
+    /// Whether the event mentions/highlights the current user. `None` when the
+    /// push actions couldn't be determined.
+    pub has_mention: Option<bool>,
+    /// The root event id of the thread this event belongs to, if any.
+    pub thread_id: Option<OwnedEventId>,
+}

--- a/src/models/state_updater.rs
+++ b/src/models/state_updater.rs
@@ -1,7 +1,7 @@
 use matrix_sdk::{
     AuthSession,
     encryption::recovery::RecoveryState,
-    ruma::{OwnedMxcUri, OwnedUserId},
+    ruma::{OwnedMxcUri, OwnedUserId, RoomId},
 };
 
 use crate::{
@@ -42,4 +42,10 @@ pub trait StateUpdaterFunctions {
     async fn persist_refreshed_session(&self, refreshed_session: AuthSession)
     -> anyhow::Result<()>;
     async fn persist_login_session(&self, session: String) -> anyhow::Result<()>;
+    /// Called when a joined room's unread count drops to zero (the room was read
+    /// on this or another device). Lets the embedder dismiss any OS notification
+    /// it posted for that room. Defaults to a no-op.
+    fn room_fully_read(&self, _room_id: &RoomId) -> anyhow::Result<()> {
+        Ok(())
+    }
 }

--- a/src/models/state_updater.rs
+++ b/src/models/state_updater.rs
@@ -1,7 +1,7 @@
 use matrix_sdk::{
     AuthSession,
     encryption::recovery::RecoveryState,
-    ruma::{OwnedMxcUri, OwnedUserId, RoomId},
+    ruma::{OwnedMxcUri, OwnedUserId},
 };
 
 use crate::{
@@ -42,10 +42,4 @@ pub trait StateUpdaterFunctions {
     async fn persist_refreshed_session(&self, refreshed_session: AuthSession)
     -> anyhow::Result<()>;
     async fn persist_login_session(&self, session: String) -> anyhow::Result<()>;
-    /// Called when a joined room's unread count drops to zero (the room was read
-    /// on this or another device). Lets the embedder dismiss any OS notification
-    /// it posted for that room. Defaults to a no-op.
-    fn room_fully_read(&self, _room_id: &RoomId) -> anyhow::Result<()> {
-        Ok(())
-    }
 }

--- a/src/room/notifications.rs
+++ b/src/room/notifications.rs
@@ -109,26 +109,11 @@ fn get_http_pusher(
     // For iOS we define here the content of the notification.
     // For android, it is defined server-side.
     if cfg!(target_os = "ios") {
-        // Poor localization of the alert, to be improved
-        let title = if user_language.eq("fr") {
-            "Nouveau message"
-        } else {
-            "New message"
-        };
-        let body = if user_language.eq("fr") {
-            "Appuyez pour voir le message"
-        } else {
-            "Tap to view message"
-        };
-
         let default_payload = json!( {
           "aps": {
               "mutable-content": 1,
               "content-available": 1,
-              "alert": {
-                  "title": title,
-                  "body": body
-              }
+              "alert": {"loc-key": "SINGLE_UNREAD", "loc-args": []}
           }
         });
         let mut pusher_data = Map::new();

--- a/src/room/notifications.rs
+++ b/src/room/notifications.rs
@@ -4,7 +4,7 @@ use crate::{
     models::events::{EmitEvent, ToastNotificationRequest},
 };
 use crossbeam_queue::SegQueue;
-use matrix_sdk::Client;
+use matrix_sdk::{Client, ruma::events::AnySyncTimelineEvent};
 
 // Platform imports
 #[cfg(any(target_os = "android", target_os = "ios"))]
@@ -15,7 +15,7 @@ use matrix_sdk::ruma::api::client::push::{Pusher, PusherIds, PusherInit, PusherK
 use matrix_sdk::{
     Room,
     notification_settings::{NotificationSettings, RoomNotificationMode},
-    ruma::{MilliSecondsSinceUnixEpoch, events::AnySyncTimelineEvent, serde::Raw},
+    ruma::{MilliSecondsSinceUnixEpoch, serde::Raw},
 };
 #[cfg(any(target_os = "android", target_os = "ios"))]
 use serde_json::{Map, json};
@@ -286,7 +286,6 @@ pub async fn parse_full_notification(
     Ok((summary, body, server_ts))
 }
 
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub fn event_notification_body(event: &AnySyncTimelineEvent, sender_name: &str) -> Option<String> {
     use matrix_sdk::ruma::events::AnyMessageLikeEventContent;
 
@@ -332,8 +331,7 @@ pub fn event_notification_body(event: &AnySyncTimelineEvent, sender_name: &str) 
     }
 }
 
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
-fn truncate(s: String) -> String {
+pub fn truncate(s: String) -> String {
     use unicode_segmentation::UnicodeSegmentation;
 
     static MAX_LENGTH: usize = 5000;

--- a/src/room/notifications.rs
+++ b/src/room/notifications.rs
@@ -55,6 +55,12 @@ pub fn process_toast_notifications() {
 //
 
 /// For user_language: The preferred language for receiving notifications (e.g. ‘en’ or ‘en-US’).
+///
+/// On iOS the pusher's fallback alert (shown verbatim by the OS whenever the
+/// Notification Service Extension fails, times out or is not configured) uses
+/// the localization key `SINGLE_UNREAD`: the embedding app **must** define it
+/// in its `Localizable.strings`, otherwise users see the raw key as the
+/// notification text.
 #[cfg(any(target_os = "android", target_os = "ios"))]
 pub async fn register_mobile_push_notifications(
     client: &Client,
@@ -64,7 +70,7 @@ pub async fn register_mobile_push_notifications(
     ios_sygnal_url: Url,
     app_id: String,
 ) -> anyhow::Result<()> {
-    let http_pusher = get_http_pusher(user_language.clone(), android_sygnal_url, ios_sygnal_url);
+    let http_pusher = get_http_pusher(android_sygnal_url, ios_sygnal_url);
     let pusher_ids = PusherIds::new(token, app_id);
 
     let device_display_name = client
@@ -92,7 +98,6 @@ pub async fn register_mobile_push_notifications(
 
 #[cfg(any(target_os = "android", target_os = "ios"))]
 fn get_http_pusher(
-    user_language: String,
     android_sygnal_url: Url,
     ios_sygnal_url: Url,
 ) -> matrix_sdk::ruma::push::HttpPusherData {
@@ -109,6 +114,9 @@ fn get_http_pusher(
     // For iOS we define here the content of the notification.
     // For android, it is defined server-side.
     if cfg!(target_os = "ios") {
+        // Fallback alert when the NSE doesn't rewrite the notification: the
+        // `SINGLE_UNREAD` key must exist in the app's Localizable.strings (see
+        // `register_mobile_push_notifications`).
         let default_payload = json!( {
           "aps": {
               "mutable-content": 1,
@@ -306,7 +314,7 @@ pub fn event_notification_body(event: &AnySyncTimelineEvent, sender_name: &str) 
                     format!("{sender_name} sent a verification request.")
                 }
                 _ => {
-                    format!("[Unknown message type: {:?}]", &message.msgtype)
+                    format!("[Unknown message type: {:?}]", message.msgtype)
                 }
             };
             Some(body)

--- a/src/room/rooms_list.rs
+++ b/src/room/rooms_list.rs
@@ -23,9 +23,9 @@ use tokio::{
 
 use crate::{
     events::timeline::TimelineKind,
-    init::singletons::{ALL_ROOMS_LOADED, UIUpdateMessage, broadcast_event},
+    init::singletons::{ALL_ROOMS_LOADED, UIUpdateMessage, broadcast_event, get_event_bridge},
     models::{
-        events::{ToastNotificationRequest, ToastNotificationVariant},
+        events::{EmitEvent, ToastNotificationRequest, ToastNotificationVariant},
         room_display_name::FrontendRoomDisplayName,
         state_updater::StateUpdater,
     },
@@ -127,6 +127,15 @@ static PENDING_ROOM_UPDATES: SegQueue<RoomsListUpdate> = SegQueue::new();
 pub fn enqueue_rooms_list_update(update: RoomsListUpdate) {
     PENDING_ROOM_UPDATES.push(update);
     broadcast_event(UIUpdateMessage::RefreshUI);
+}
+
+/// Tell the embedder a joined room has no unread messages left so it can
+/// dismiss any OS notification it posted for it (see
+/// [`EmitEvent::RoomFullyRead`]). Fire-and-forget; dismissals are idempotent.
+fn notify_room_fully_read(room_id: &OwnedRoomId) {
+    if let Ok(bridge) = get_event_bridge() {
+        bridge.emit(EmitEvent::RoomFullyRead(room_id.clone()));
+    }
 }
 
 /// UI-related info about a joined room.
@@ -343,6 +352,14 @@ impl RoomsList {
                     let should_display = (self.display_filter)(&joined_room);
                     let is_direct = joined_room.is_direct;
 
+                    // A room entering the list already fully read may have been
+                    // read on another device while this app was down: signal it
+                    // so any stale OS notification gets dismissed (the
+                    // transition check below can't fire for those rooms).
+                    if joined_room.num_unread_messages == 0 && !joined_room.is_marked_unread {
+                        notify_room_fully_read(&room_id);
+                    }
+
                     let replaced = self.all_joined_rooms.insert(room_id.clone(), joined_room);
 
                     if let Some(_old_room) = replaced {
@@ -400,14 +417,9 @@ impl RoomsList {
                         room.num_unread_mentions = unread_mentions;
                         room.is_marked_unread = is_marked_unread;
                         // The room just went from unread to fully read (a receipt
-                        // from this or another device): let the embedder dismiss
-                        // any OS notification it posted for it.
+                        // from this or another device).
                         if old_count > 0 && room.num_unread_messages == 0 && !is_marked_unread {
-                            if let Err(e) = self.state_updaters.room_fully_read(&room_id) {
-                                error!(
-                                    "Failed to notify embedder that room {room_id} was read: {e}"
-                                );
-                            }
+                            notify_room_fully_read(&room_id);
                         }
                     } else {
                         warn!(

--- a/src/room/rooms_list.rs
+++ b/src/room/rooms_list.rs
@@ -392,12 +392,23 @@ impl RoomsList {
                     unread_mentions,
                 } => {
                     if let Some(room) = self.all_joined_rooms.get_mut(&room_id) {
+                        let old_count = room.num_unread_messages;
                         room.num_unread_messages = match unread_messages {
                             UnreadMessageCount::_Unknown => 0,
                             UnreadMessageCount::Known(count) => count,
                         };
                         room.num_unread_mentions = unread_mentions;
                         room.is_marked_unread = is_marked_unread;
+                        // The room just went from unread to fully read (a receipt
+                        // from this or another device): let the embedder dismiss
+                        // any OS notification it posted for it.
+                        if old_count > 0 && room.num_unread_messages == 0 && !is_marked_unread {
+                            if let Err(e) = self.state_updaters.room_fully_read(&room_id) {
+                                error!(
+                                    "Failed to notify embedder that room {room_id} was read: {e}"
+                                );
+                            }
+                        }
                     } else {
                         warn!(
                             "Warning: couldn't find room {} to update unread messages count",


### PR DESCRIPTION
Before this PR, there was no way to get a "notifications client", the dedicated client for short syncs necessary to decrypt a silent notification payload. 

This PR has been heavily written by an AI (Claude Code), but it has been reviewed by an human. 
It relies on my fork of [tauri-plugin-notifications](https://github.com/IT-ess/tauri-plugin-notifications/tree/silent-notifications).